### PR TITLE
Switch to Playwright-based Instagram checker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 __pycache__/
+playwright_state.json

--- a/instagram_checker.py
+++ b/instagram_checker.py
@@ -1,97 +1,80 @@
 import os
-import logging
-from typing import Optional
-
+import asyncio
 from dotenv import load_dotenv
-from instagrapi import Client
+from playwright.async_api import async_playwright
 
-SESSION_FILE = "ig_session.json"
+STATE_FILE = "playwright_state.json"
+USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/116.0.0.0 Safari/537.36"
+)
 
 load_dotenv()
-
 IG_USERNAME = os.getenv("IG_USERNAME")
 IG_PASSWORD = os.getenv("IG_PASSWORD")
 
-logging.basicConfig(level=logging.INFO, format="%(message)s")
 
-
-def _login() -> Optional['Client']:
-    """Login to Instagram using instagrapi.Client and return the client."""
-    if not IG_USERNAME or not IG_PASSWORD:
-        logging.error("IG_USERNAME or IG_PASSWORD not provided in .env")
-        return None
-
-    client = Client()
-
-    if os.path.exists(SESSION_FILE):
+async def _perform_login(page) -> None:
+    await page.goto("https://www.instagram.com/accounts/login/", wait_until="networkidle")
+    await page.fill("input[name='username']", IG_USERNAME)
+    await page.fill("input[name='password']", IG_PASSWORD)
+    await page.click("button[type='submit']")
+    await page.wait_for_load_state("networkidle")
+    # Dismiss possible dialogs like "Save Your Login Info?" or notifications
+    for text in ["Not Now", "Не сейчас", "Save Info", "Сохранить информацию"]:
         try:
-            client.load_settings(SESSION_FILE)
-            client.login(IG_USERNAME, IG_PASSWORD)
-            return client
-        except Exception as exc:
-            logging.warning(f"Failed to reuse session: {exc}")
-
-    try:
-        client.login(IG_USERNAME, IG_PASSWORD)
-        client.dump_settings(SESSION_FILE)
-        return client
-    except Exception as exc:
-        logging.error(f"Instagram login failed: {exc}")
-        return None
-
-
-def check_unread_messages(limit: int = 5) -> bool:
-    """Check Instagram direct messages for unread threads.
-
-    Args:
-        limit: Number of recent threads to inspect.
-
-    Returns:
-        True if there are unread messages, otherwise False.
-    """
-    client = _login()
-    if not client:
-        return False
-
-    try:
-        threads = client.direct_threads(amount=limit)
-    except Exception as exc:
-        logging.error(f"Failed to fetch messages: {exc}")
-        return False
-
-    unread_total = 0
-    messages_output = []
-
-    for thread in threads:
-        if not thread.messages:
-            continue
-        last_msg = thread.messages[-1]
-        user_id = last_msg.user_id
-        try:
-            username = "@" + client.user_info(user_id).username
+            await page.click(f"text={text}", timeout=3000)
         except Exception:
-            username = str(user_id)
+            pass
 
-        text = last_msg.text or ""
-        unread = not last_msg.seen
-        if unread:
-            unread_total += 1
-        messages_output.append(
-            f"- От {username}: \"{text}\" [{'непрочитано' if unread else 'прочитано'}]"
-        )
 
-    if unread_total:
-        print(f"Есть {unread_total} непрочитанных сообщений.")
-    else:
-        print("Непрочитанных сообщений нет.")
+async def _ensure_context(browser):
+    context_args = {"user_agent": USER_AGENT}
+    if os.path.exists(STATE_FILE):
+        context_args["storage_state"] = STATE_FILE
+    context = await browser.new_context(**context_args)
+    page = await context.new_page()
+    await page.goto("https://www.instagram.com/", wait_until="networkidle")
+    if "login" in page.url:
+        if not IG_USERNAME or not IG_PASSWORD:
+            raise RuntimeError("IG_USERNAME or IG_PASSWORD not set in .env")
+        await _perform_login(page)
+        await context.storage_state(path=STATE_FILE)
+    return context, page
 
-    if messages_output:
-        print("Последние:")
-        for line in messages_output:
-            print(line)
 
-    return bool(unread_total)
+async def _collect_unread(page):
+    await page.goto("https://www.instagram.com/direct/inbox/", wait_until="networkidle")
+    await page.wait_for_selector("a[href*='/direct/t/']")
+    threads = page.locator("a[href*='/direct/t/']")
+    unread = []
+    count = await threads.count()
+    for i in range(count):
+        item = threads.nth(i)
+        is_unread = False
+        if await item.locator("svg[aria-label='Unread']").count() > 0:
+            is_unread = True
+        elif await item.locator("div[style*='font-weight: 600']").count() > 0:
+            is_unread = True
+        username = await item.locator("div[dir='auto'] span").first.inner_text()
+        last_message = await item.locator("div[dir='auto']").nth(-1).inner_text()
+        if is_unread:
+            unread.append((username, last_message))
+    return unread
+
+
+async def main() -> None:
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=True)
+        context, page = await _ensure_context(browser)
+        unread = await _collect_unread(page)
+        print(f"Количество непрочитанных тредов: {len(unread)}")
+        for username, text in unread:
+            print(f"- {username}: {text}")
+        await context.close()
+        await browser.close()
 
 
 if __name__ == "__main__":
-    check_unread_messages()
+    asyncio.run(main())

--- a/main.py
+++ b/main.py
@@ -1,15 +1,16 @@
 import asyncio
-from instagram_checker import check_unread_messages
+from instagram_checker import main as check_unread_messages
 
 
 async def periodic_check() -> None:
     """Periodically check Instagram for unread messages."""
     while True:
         try:
-            check_unread_messages()
+            await check_unread_messages()
         except Exception as exc:
             print(f"Error during check: {exc}")
         await asyncio.sleep(300)
+
 
 if __name__ == "__main__":
     print("🚀 Bot is running...")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 aiogram
 python-dotenv
-instagrapi
+playwright


### PR DESCRIPTION
## Summary
- replace `instagrapi` direct API usage with Playwright automation
- remove old API session logic
- update async loop to await the new function
- drop `instagrapi` dependency, add `playwright`
- ignore Playwright's state file

## Testing
- `python -m pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement playwright)*
- `python -m py_compile instagram_checker.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68506e122d78832398a789979afb0038